### PR TITLE
[README] Add commands to install packer plugins manually.

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -72,3 +72,14 @@ removing this key from the VM before exporting it, so that VMs created from
 the image cannot be compromised using this key.
 
 <!-- vi: set tw=72 et sw=2 fo=tcroqan autoindent: -->
+
+## Packer >= 1.10
+
+Since version 1.10 Packer stopped bundling plugins therefore they need
+to be installed manually:
+
+```sh
+packer plugins install github.com/hashicorp/ansible
+packer plugins install github.com/hashicorp/virtualbox
+```
+


### PR DESCRIPTION
Issue #33 

Since packer v1.10 doesn't include all the necessary plugins to complete building virtual machine.

Those plugins need to be installed manually.
